### PR TITLE
Fix navbar placement in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}  <Navbar /></body>
+      <body className={inter.className}>
+        <Navbar />
+        {children}
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import Navbar from "@/components/navbar"
 import HeroSection from "@/components/hero-section"
 
 export default function HomePage() {


### PR DESCRIPTION
## Summary
- place the Navbar before page content in the root layout
- clean up an unused Navbar import on the home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c98ba220832d886af4aa219ceaa0