### PR TITLE
Fix nav label for Places to Play

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -16,7 +16,7 @@ const navigationItems: NavItem[] = [
     label: "About DFWTT",href: "/about"
   },
      { label: "Join Us", href: "/join-us" },
-  { label: "Place to Play", href: "/places-to-play" },
+  { label: "Places to Play", href: "/places-to-play" },
   { label: "Coaching", href: "/coaching" },
   {
     label: "News & Info",


### PR DESCRIPTION
## Summary
- fix text label in navbar from `Place to Play` to `Places to Play`

## Testing
- `npm run lint` *(fails: asks about configuring ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6864cb4417d8832d8c0ed2ca875a042f